### PR TITLE
Add Serena MCP-powered repository QA agent

### DIFF
--- a/src/clean_interfaces/agents/__init__.py
+++ b/src/clean_interfaces/agents/__init__.py
@@ -1,6 +1,6 @@
 """Factories for Clean Interfaces agents."""
 
 from clean_interfaces.agents.coding import create_coding_agent
+from clean_interfaces.agents.repo_qa import create_repository_qa_agent
 
-__all__ = ["create_coding_agent"]
-
+__all__ = ["create_coding_agent", "create_repository_qa_agent"]

--- a/src/clean_interfaces/agents/repo_qa.py
+++ b/src/clean_interfaces/agents/repo_qa.py
@@ -1,0 +1,36 @@
+"""Factories for repository question-answering agents."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+from clean_interfaces.mcp import create_lsp_walker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from clean_interfaces.utils.settings import AgentSettings, MCPSettings
+
+
+def create_repository_qa_agent(
+    *,
+    settings: AgentSettings,
+    mcp_settings: MCPSettings,
+    instructions: str,
+    project_path: Path | None = None,
+) -> Agent:
+    """Create an agent configured for repository exploration."""
+    model = OpenAIChat(id=settings.openai_model, api_key=settings.openai_api_key)
+
+    walker = create_lsp_walker(mcp_settings, project_path=project_path)
+    toolkit = walker.create_toolkit()
+
+    return Agent(
+        model=model,
+        name=settings.agent_name,
+        instructions=instructions,
+        tools=[toolkit],
+    )

--- a/src/clean_interfaces/mcp/__init__.py
+++ b/src/clean_interfaces/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""Factories and implementations for Model Context Protocol helpers."""
+
+from .base import BaseLSPWalker
+from .factory import create_lsp_walker
+
+__all__ = ["BaseLSPWalker", "create_lsp_walker"]

--- a/src/clean_interfaces/mcp/base.py
+++ b/src/clean_interfaces/mcp/base.py
@@ -1,0 +1,28 @@
+"""Base interfaces for Model Context Protocol integrations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agno.tools.mcp import MCPTools
+
+
+class BaseLSPWalker(ABC):
+    """Abstract base class for LSP-oriented MCP walkers."""
+
+    def __init__(self, *, project_path: Path | None = None) -> None:
+        """Store the optional project path to explore."""
+        self._project_path = project_path.resolve() if project_path else None
+
+    @property
+    def project_path(self) -> Path | None:
+        """Return the resolved project path if one was provided."""
+        return self._project_path
+
+    @abstractmethod
+    def create_toolkit(self) -> MCPTools:
+        """Return a configured MCP toolkit for the walker."""

--- a/src/clean_interfaces/mcp/factory.py
+++ b/src/clean_interfaces/mcp/factory.py
@@ -1,0 +1,29 @@
+"""Factory helpers for creating MCP walker implementations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .serena import SerenaLSPWalker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from clean_interfaces.utils.settings import MCPSettings
+
+    from .base import BaseLSPWalker
+
+
+def create_lsp_walker(
+    settings: MCPSettings,
+    *,
+    project_path: Path | None = None,
+) -> BaseLSPWalker:
+    """Create an LSP walker implementation based on configuration."""
+    provider = settings.lsp_walker_provider.lower()
+
+    if provider == "serena":
+        return SerenaLSPWalker(settings=settings, project_path=project_path)
+
+    msg = f"Unsupported LSP walker provider: {settings.lsp_walker_provider}"
+    raise ValueError(msg)

--- a/src/clean_interfaces/mcp/serena.py
+++ b/src/clean_interfaces/mcp/serena.py
@@ -1,0 +1,75 @@
+"""Serena-specific MCP walker implementation."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from agno.tools.mcp import MCPTools
+
+from .base import BaseLSPWalker
+
+if TYPE_CHECKING:
+    from clean_interfaces.utils.settings import MCPSettings
+
+
+class SerenaLSPWalker(BaseLSPWalker):
+    """LSP walker that launches the Serena MCP server."""
+
+    def __init__(
+        self,
+        settings: MCPSettings,
+        *,
+        project_path: Path | None = None,
+    ) -> None:
+        """Initialise the Serena walker with configuration and project path."""
+        super().__init__(project_path=project_path)
+        self._settings = settings
+
+    def _has_flag(self, parts: list[str], flag: str) -> bool:
+        """Return whether the command parts already include a given flag."""
+        flag_prefix = f"{flag}="
+        return any(part == flag or part.startswith(flag_prefix) for part in parts)
+
+    def _resolve_project_path(self) -> Path:
+        """Resolve the project path to use when launching the server."""
+        if self.project_path is not None:
+            return self.project_path
+        return Path.cwd().resolve()
+
+    def _build_command(self) -> str | None:
+        base_command = self._settings.lsp_walker_command.strip()
+        if not base_command:
+            return None
+
+        parts = shlex.split(base_command)
+
+        if self._settings.lsp_walker_context and not self._has_flag(parts, "--context"):
+            parts.extend(["--context", self._settings.lsp_walker_context])
+
+        project_path = self._resolve_project_path()
+        if not self._has_flag(parts, "--project"):
+            parts.extend(["--project", str(project_path)])
+
+        return shlex.join(parts)
+
+    def create_toolkit(self) -> MCPTools:
+        """Return a configured MCP toolkit for the Serena walker."""
+        command = self._build_command()
+        kwargs: dict[str, Any] = {
+            "transport": self._settings.lsp_walker_transport,
+            "timeout_seconds": self._settings.lsp_walker_timeout_seconds,
+        }
+
+        if self._settings.lsp_walker_url:
+            kwargs["url"] = self._settings.lsp_walker_url
+
+        if command:
+            kwargs["command"] = command
+
+        if self._settings.lsp_walker_transport == "stdio" and not command:
+            msg = "Serena LSP walker requires a command when using stdio transport"
+            raise ValueError(msg)
+
+        return MCPTools(**kwargs)

--- a/src/clean_interfaces/prompts/repository_qa_agent.md
+++ b/src/clean_interfaces/prompts/repository_qa_agent.md
@@ -1,0 +1,6 @@
+You are a repository question answering assistant.
+- Explore the provided project using the connected MCP tools.
+- Focus on the directory specified by the user when available.
+- Provide concise answers grounded in the project files.
+- Include file references when citing code snippets.
+- If information is missing, explain what additional context would be required.

--- a/src/clean_interfaces/utils/settings.py
+++ b/src/clean_interfaces/utils/settings.py
@@ -181,6 +181,48 @@ class AgentSettings(BaseSettings):
     )
 
 
+class MCPSettings(BaseSettings):
+    """Configuration for MCP integrations used by agents."""
+
+    instance: ClassVar[Any] = None
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+        env_prefix="MCP_",
+    )
+
+    lsp_walker_provider: Literal["serena"] = Field(
+        default="serena",
+        description="Identifier for the LSP walker provider to use.",
+    )
+    lsp_walker_command: str = Field(
+        default=(
+            "uvx --from git+https://github.com/oraios/serena serena start-mcp-server"
+        ),
+        description="Command used to launch the default LSP walker MCP server.",
+    )
+    lsp_walker_context: str | None = Field(
+        default="ide-assistant",
+        description="Optional context passed to the MCP server.",
+    )
+    lsp_walker_transport: Literal["stdio", "sse", "streamable-http"] = Field(
+        default="stdio",
+        description="Transport protocol used to connect to the MCP server.",
+    )
+    lsp_walker_timeout_seconds: int = Field(
+        default=60,
+        description="Read timeout applied when communicating with the MCP server.",
+        ge=1,
+    )
+    lsp_walker_url: str | None = Field(
+        default=None,
+        description="Optional URL for transports that require explicit endpoints.",
+    )
+
+
 def get_settings() -> LoggingSettings:
     """Get the global settings instance.
 
@@ -231,3 +273,15 @@ def get_agent_settings() -> AgentSettings:
 def reset_agent_settings() -> None:
     """Reset the global agent settings instance."""
     AgentSettings.instance = None
+
+
+def get_mcp_settings() -> MCPSettings:
+    """Get the global MCP settings instance."""
+    if MCPSettings.instance is None:
+        MCPSettings.instance = MCPSettings()
+    return MCPSettings.instance
+
+
+def reset_mcp_settings() -> None:
+    """Reset the global MCP settings instance."""
+    MCPSettings.instance = None

--- a/tests/unit/clean_interfaces/agents/__init__.py
+++ b/tests/unit/clean_interfaces/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for agent factories."""

--- a/tests/unit/clean_interfaces/agents/test_repo_qa.py
+++ b/tests/unit/clean_interfaces/agents/test_repo_qa.py
@@ -1,0 +1,49 @@
+"""Tests for repository QA agent factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from clean_interfaces.agents.repo_qa import create_repository_qa_agent
+from clean_interfaces.utils.settings import AgentSettings, MCPSettings
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_repository_qa_agent_configures_model_and_tools(tmp_path: Path) -> None:
+    """Repository QA agent should use OpenAI settings and attach MCP tools."""
+    settings = AgentSettings.model_validate(
+        {"OPENAI_API_KEY": "sk-test", "openai_model": "gpt", "agent_name": "Repo QA"},
+    )
+    mcp_settings = MCPSettings()
+
+    fake_tool = object()
+
+    with (
+        patch(
+            "clean_interfaces.agents.repo_qa.create_lsp_walker",
+        ) as mock_walker_factory,
+        patch("clean_interfaces.agents.repo_qa.OpenAIChat") as mock_openai_chat,
+    ):
+        walker_instance = MagicMock()
+        walker_instance.create_toolkit.return_value = fake_tool
+        mock_walker_factory.return_value = walker_instance
+
+        model_instance = MagicMock()
+        mock_openai_chat.return_value = model_instance
+
+        agent = create_repository_qa_agent(
+            settings=settings,
+            mcp_settings=mcp_settings,
+            instructions="Answer questions",
+            project_path=tmp_path,
+        )
+
+    mock_walker_factory.assert_called_once_with(mcp_settings, project_path=tmp_path)
+    walker_instance.create_toolkit.assert_called_once()
+    mock_openai_chat.assert_called_once_with(id="gpt", api_key="sk-test")
+
+    assert agent.model is model_instance
+    assert agent.name == "Repo QA"

--- a/tests/unit/clean_interfaces/mcp/__init__.py
+++ b/tests/unit/clean_interfaces/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for MCP helpers."""

--- a/tests/unit/clean_interfaces/mcp/test_factory.py
+++ b/tests/unit/clean_interfaces/mcp/test_factory.py
@@ -1,0 +1,26 @@
+"""Tests for MCP walker factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from clean_interfaces.mcp.factory import create_lsp_walker
+from clean_interfaces.mcp.serena import SerenaLSPWalker
+from clean_interfaces.utils.settings import MCPSettings
+
+
+def test_factory_returns_serena_walker() -> None:
+    """Factory should return Serena implementation by default."""
+    settings = MCPSettings()
+    walker = create_lsp_walker(settings)
+    assert isinstance(walker, SerenaLSPWalker)
+
+
+def test_factory_rejects_unknown_provider() -> None:
+    """Factory should raise on unsupported providers."""
+    settings = MCPSettings(lsp_walker_provider="serena")
+    # type ignore to circumvent Literal check during instantiation for test
+    settings.lsp_walker_provider = "unknown"  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="Unsupported LSP walker provider"):
+        create_lsp_walker(settings)

--- a/tests/unit/clean_interfaces/mcp/test_serena.py
+++ b/tests/unit/clean_interfaces/mcp/test_serena.py
@@ -1,0 +1,117 @@
+"""Tests for the Serena MCP walker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import clean_interfaces.mcp.serena as serena_module
+from clean_interfaces.mcp.serena import SerenaLSPWalker
+from clean_interfaces.utils.settings import MCPSettings
+
+
+class DummyMCPTools:
+    """Simple stand-in for MCPTools to capture arguments."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Record initialization keyword arguments for later assertions."""
+        self.kwargs = kwargs
+
+
+def test_serena_walker_appends_context_and_project(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The Serena walker should augment the command with context and project path."""
+    settings = MCPSettings(
+        lsp_walker_command="uvx serena start-mcp-server",
+        lsp_walker_context="ide-assistant",
+        lsp_walker_timeout_seconds=15,
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_mcp_tools(**kwargs: Any) -> DummyMCPTools:
+        captured.update(kwargs)
+        return DummyMCPTools(**kwargs)
+
+    monkeypatch.setattr(serena_module, "MCPTools", fake_mcp_tools)
+
+    walker = SerenaLSPWalker(settings=settings, project_path=tmp_path)
+    toolkit = walker.create_toolkit()
+
+    assert isinstance(toolkit, DummyMCPTools)
+    assert captured["transport"] == "stdio"
+    assert captured["timeout_seconds"] == 15
+
+    command = captured["command"]
+    assert isinstance(command, str)
+    assert "--context ide-assistant" in command
+    assert f"--project {tmp_path}" in command
+
+
+def test_serena_requires_command_for_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When using stdio the walker must have a command configured."""
+    settings = MCPSettings(
+        lsp_walker_command="",  # Removed command
+        lsp_walker_context=None,
+        lsp_walker_transport="stdio",
+    )
+
+    monkeypatch.setattr(serena_module, "MCPTools", DummyMCPTools)
+
+    walker = SerenaLSPWalker(settings=settings)
+
+    with pytest.raises(ValueError, match="requires a command"):
+        walker.create_toolkit()
+
+
+def test_serena_defaults_project_to_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When no project path is provided the current directory is used."""
+    settings = MCPSettings(
+        lsp_walker_command="uvx serena start-mcp-server",
+        lsp_walker_context="ide-assistant",
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_mcp_tools(**kwargs: Any) -> DummyMCPTools:
+        captured.update(kwargs)
+        return DummyMCPTools(**kwargs)
+
+    monkeypatch.setattr(serena_module, "MCPTools", fake_mcp_tools)
+
+    walker = SerenaLSPWalker(settings=settings)
+    walker.create_toolkit()
+
+    command = captured["command"]
+    assert isinstance(command, str)
+    cwd = str(Path.cwd().resolve())
+    assert f"--project {cwd}" in command
+
+
+def test_serena_does_not_duplicate_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing flag definitions in the command should not be duplicated."""
+    settings = MCPSettings(
+        lsp_walker_command=(
+            "uvx serena start-mcp-server --context custom --project /tmp/repo"
+        ),
+        lsp_walker_context="ignored",
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_mcp_tools(**kwargs: Any) -> DummyMCPTools:
+        captured.update(kwargs)
+        return DummyMCPTools(**kwargs)
+
+    monkeypatch.setattr(serena_module, "MCPTools", fake_mcp_tools)
+
+    walker = SerenaLSPWalker(settings=settings)
+    walker.create_toolkit()
+
+    command_parts = captured["command"].split()
+    assert command_parts.count("--context") == 1
+    assert command_parts.count("--project") == 1

--- a/tests/unit/clean_interfaces/test_core.py
+++ b/tests/unit/clean_interfaces/test_core.py
@@ -1,5 +1,6 @@
 """Unit tests for core agent orchestration."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from clean_interfaces.core import (
     AgentConfigurationError,
     AgentExecutionError,
     run_coding_agent,
+    run_repository_qa_agent,
 )
 
 
@@ -67,3 +69,64 @@ def test_run_coding_agent_wraps_execution_errors() -> None:
 
         with pytest.raises(AgentExecutionError):
             run_coding_agent("Write code")
+
+
+def test_run_repo_agent_requires_api_key() -> None:
+    """The repository QA agent should validate configuration before running."""
+    with patch("clean_interfaces.core.get_agent_settings") as mock_get_settings:
+        settings = MagicMock()
+        settings.openai_api_key = None
+        mock_get_settings.return_value = settings
+
+        with pytest.raises(AgentConfigurationError):
+            run_repository_qa_agent("hello")
+
+
+def test_run_repo_agent_invokes_agent_successfully(tmp_path: Path) -> None:
+    """The repository QA agent should invoke the MCP-backed agent and return text."""
+    with (
+        patch("clean_interfaces.core.get_agent_settings") as mock_get_settings,
+        patch("clean_interfaces.core.get_mcp_settings") as mock_get_mcp_settings,
+        patch("clean_interfaces.core.load_prompt") as mock_load_prompt,
+        patch("clean_interfaces.core.create_repository_qa_agent") as mock_create_agent,
+    ):
+        settings = MagicMock()
+        settings.openai_api_key = "sk-test"
+        mock_get_settings.return_value = settings
+        mock_get_mcp_settings.return_value = MagicMock()
+        mock_load_prompt.return_value = "Repo prompt"
+
+        agent_instance = MagicMock()
+        result = MagicMock()
+        result.get_content_as_string.return_value = "Repo answer"
+        agent_instance.run.return_value = result
+        mock_create_agent.return_value = agent_instance
+
+        response = run_repository_qa_agent("Where is config?", project_path=tmp_path)
+
+        mock_load_prompt.assert_called_once_with("repository_qa_agent")
+        mock_create_agent.assert_called_once()
+        agent_instance.run.assert_called_once_with("Where is config?")
+        assert response == "Repo answer"
+
+
+def test_run_repo_agent_wraps_execution_errors(tmp_path: Path) -> None:
+    """Execution failures should be wrapped in domain-specific errors."""
+    with (
+        patch("clean_interfaces.core.get_agent_settings") as mock_get_settings,
+        patch("clean_interfaces.core.get_mcp_settings") as mock_get_mcp_settings,
+        patch("clean_interfaces.core.load_prompt") as mock_load_prompt,
+        patch("clean_interfaces.core.create_repository_qa_agent") as mock_create_agent,
+    ):
+        settings = MagicMock()
+        settings.openai_api_key = "sk-test"
+        mock_get_settings.return_value = settings
+        mock_get_mcp_settings.return_value = MagicMock()
+        mock_load_prompt.return_value = "Repo prompt"
+
+        agent_instance = MagicMock()
+        agent_instance.run.side_effect = RuntimeError("boom")
+        mock_create_agent.return_value = agent_instance
+
+        with pytest.raises(AgentExecutionError):
+            run_repository_qa_agent("Where is config?", project_path=tmp_path)


### PR DESCRIPTION
## Summary
- add a Serena-based MCP walker abstraction and repository QA agent factory
- wire the new agent through core orchestration, CLI command, and prompt assets
- cover the MCP integration with targeted unit tests for factories, walker, and CLI behaviour
- ensure the Serena walker defaults to the working directory when no project path is supplied and avoids duplicating existing flags

## Testing
- `uv run nox -s ci` *(fails: security-3.13 due to SSL certificate verification error when running pip-audit; linting, typing, and tests succeeded)*

------
https://chatgpt.com/codex/tasks/task_e_68d23280a0008330b6e0c9fbcbdda6ff