### PR TITLE
Use Scenario library for end-to-end agent tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "responses>=0.25.3",
     "pexpect>=4.9.0",
     "pytest-asyncio>=0.23.0",
+    "langwatch-scenario>=0.7.11",
     "diff-cover>=8.0.0",
     "commitizen>=3.20.0",
     "python-semantic-release>=8.10.0",
@@ -150,11 +151,12 @@ reportMissingTypeStubs = false
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
-addopts = "-v -ra --strict-markers" # This will be replaced by setup.sh
+addopts = "-v -ra --strict-markers -m 'not scenario'" # This will be replaced by setup.sh
 markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
   "integration: marks integration tests",
-  "asyncio: marks tests as asyncio"
+  "asyncio: marks tests as asyncio",
+  "scenario: marks Scenario-based tests that require external LLM credentials",
 ]
 
 [dependency-groups]

--- a/src/clean_interfaces/llm/__init__.py
+++ b/src/clean_interfaces/llm/__init__.py
@@ -4,5 +4,5 @@ This package exposes a factory to create provider-specific model instances.
 """
 from .factory import create_model, LLMProviderNotAvailableError
 
-__all__ = ["create_model", "LLMProviderNotAvailableError"]
+__all__ = ["LLMProviderNotAvailableError", "create_model"]
 

--- a/src/clean_interfaces/llm/factory.py
+++ b/src/clean_interfaces/llm/factory.py
@@ -9,6 +9,7 @@ Notes:
   to preserve existing test hooks that patch that symbol in those modules.
 - For other providers, this factory returns the appropriate model instance if
   the corresponding integration is available in ``agno``.
+
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ class LLMProviderNotAvailableError(RuntimeError):
     """Raised when the requested provider integration is not available."""
 
 
-def _build_openai_model(settings: "AgentSettings") -> Any:
+def _build_openai_model(settings: AgentSettings) -> Any:
     """Construct an OpenAIChat model using OpenAI credentials.
 
     Although agents instantiate OpenAI models directly, this is exposed for
@@ -48,7 +49,7 @@ def _build_openai_model(settings: "AgentSettings") -> Any:
     return OpenAIChat(**kwargs)
 
 
-def _build_azure_openai_model(settings: "AgentSettings") -> Any:
+def _build_azure_openai_model(settings: AgentSettings) -> Any:
     """Construct an Azure OpenAI model instance.
 
     Attempts multiple import paths to accommodate possible agno versions.
@@ -60,7 +61,7 @@ def _build_azure_openai_model(settings: "AgentSettings") -> Any:
     ):
         try:
             module = __import__(path, fromlist=["AzureOpenAIChat"])  # type: ignore[assignment]
-            model_class = getattr(module, "AzureOpenAIChat")
+            model_class = module.AzureOpenAIChat
             break
         except Exception as exc:  # pragma: no cover - optional integration
             logger.debug("AzureOpenAIChat import failed from %s: %s", path, exc)
@@ -95,7 +96,7 @@ def _build_azure_openai_model(settings: "AgentSettings") -> Any:
     )
 
 
-def _build_anthropic_model(settings: "AgentSettings") -> Any:
+def _build_anthropic_model(settings: AgentSettings) -> Any:
     """Construct an Anthropic model instance."""
     model_class: Any | None = None
     for path in (
@@ -103,7 +104,7 @@ def _build_anthropic_model(settings: "AgentSettings") -> Any:
     ):
         try:
             module = __import__(path, fromlist=["AnthropicChat"])  # type: ignore[assignment]
-            model_class = getattr(module, "AnthropicChat")
+            model_class = module.AnthropicChat
             break
         except Exception as exc:  # pragma: no cover - optional integration
             logger.debug("AnthropicChat import failed from %s: %s", path, exc)
@@ -125,7 +126,7 @@ def _build_anthropic_model(settings: "AgentSettings") -> Any:
     return model_class(**kwargs)
 
 
-def _build_gemini_model(settings: "AgentSettings") -> Any:
+def _build_gemini_model(settings: AgentSettings) -> Any:
     """Construct a Google Gemini model instance."""
     model_class: Any | None = None
     for path in (
@@ -134,7 +135,7 @@ def _build_gemini_model(settings: "AgentSettings") -> Any:
     ):
         try:
             module = __import__(path, fromlist=["GeminiChat"])  # type: ignore[assignment]
-            model_class = getattr(module, "GeminiChat")
+            model_class = module.GeminiChat
             break
         except Exception as exc:  # pragma: no cover - optional integration
             logger.debug("GeminiChat import failed from %s: %s", path, exc)
@@ -156,7 +157,7 @@ def _build_gemini_model(settings: "AgentSettings") -> Any:
     return model_class(**kwargs)
 
 
-def create_model(settings: "AgentSettings") -> Any:
+def create_model(settings: AgentSettings) -> Any:
     """Create a provider-specific agno model instance.
 
     Args:
@@ -168,6 +169,7 @@ def create_model(settings: "AgentSettings") -> Any:
     Raises:
         LLMProviderNotAvailableError: If the provider's model is not available.
         ValueError: If the provider is unsupported or configuration is incomplete.
+
     """
     provider = getattr(settings, "provider", "openai")
     if provider == "openai":

--- a/tests/e2e/test_scenario_agents.py
+++ b/tests/e2e/test_scenario_agents.py
@@ -1,0 +1,449 @@
+"""Scenario-based end-to-end tests for agno agents and workflows."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from collections.abc import Iterable, Sequence
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
+
+import pytest
+from agno.agent import RunOutput  # noqa: TC002
+from clean_interfaces.agents.repo_qa import create_repository_qa_agent
+from clean_interfaces.agents.serena_coder import create_serena_coder_agent
+from clean_interfaces.utils.settings import AgentSettings, MCPSettings
+from clean_interfaces.workflow.tdd import TDDWorkflowConfig, create_tdd_workflow
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from agno.agent import Message
+    from agno.run.workflow import WorkflowRunOutput
+    from agno.workflow.workflow import Workflow
+    from scenario import AgentInput, AgentReturnTypes
+else:  # pragma: no cover - runtime fallbacks for typing names
+    AgentInput = AgentReturnTypes = Any
+
+
+scenario = cast(
+    "Any",
+    pytest.importorskip(  # type: ignore[attr-defined]
+        "scenario",
+        reason="Scenario tests require the scenario package and external model access.",
+    ),
+)
+
+pytest = cast("Any", pytest)
+
+pytestmark: Any = pytest.mark.scenario
+
+
+def _get_env(name: str) -> str | None:
+    """Return the trimmed environment variable if present."""
+    value = os.getenv(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+@lru_cache(maxsize=1)
+def _configure_scenario() -> None:
+    """Configure the Scenario test harness with deterministic defaults."""
+    scenario.configure(
+        default_model=_get_env("SCENARIO_DEFAULT_MODEL") or "openai/gpt-4.1-mini",
+        cache_key=_get_env("SCENARIO_CACHE_KEY") or "clean-interfaces-scenario-suite",
+        max_turns=8,
+    )
+
+
+def _require_credentials() -> None:
+    """Skip Scenario tests when the required credentials are missing."""
+    provider = _get_env("AGNO_PROVIDER") or "openai"
+    if provider == "openai" and not _get_env("OPENAI_API_KEY"):
+        pytest.skip(  # type: ignore[attr-defined]
+            "Scenario tests require OPENAI_API_KEY for the OpenAI provider.",
+        )
+
+
+def _format_agent_messages(messages: Sequence[Message] | None) -> list[dict[str, Any]]:
+    """Convert agno messages into OpenAI-compatible dictionaries."""
+    if not messages:
+        return []
+    return [message.to_dict() for message in messages]
+
+
+class _AgentTextRunner:
+    """Helper that exposes agno agents as callable text runners for workflows."""
+
+    def __init__(
+        self,
+        agent: Any,
+        *,
+        project_path: Path | None,
+        session_prefix: str,
+    ) -> None:
+        self._agent = agent
+        self._project_path = project_path
+        self._session_id = f"{session_prefix}-{uuid4()}"
+
+    def __call__(self, prompt: str, project_path: Path | None = None) -> str:
+        effective_path = project_path or self._project_path
+        effective_prompt = prompt
+        if effective_path:
+            effective_prompt = f"{prompt}\n\nRepository root: {effective_path}"
+        result = cast(
+            "RunOutput",
+            self._agent.run(  # type: ignore[reportUnknownMemberType]
+                effective_prompt,
+                session_id=self._session_id,
+            ),
+        )
+        if result.content:
+            return cast(
+                "str",
+                result.get_content_as_string(),  # type: ignore[reportUnknownMemberType]
+            )
+        responses = [msg["content"] for msg in _format_agent_messages(result.messages)]
+        return "\n\n".join(str(part) for part in responses if part)
+
+
+class SerenaCodingAdapter(scenario.AgentAdapter):  # type: ignore[misc]
+    """Adapter that exposes the Serena coding agent to the Scenario framework."""
+
+    def __init__(
+        self,
+        *,
+        project_path: Path,
+        agent_settings: AgentSettings,
+        mcp_settings: MCPSettings,
+        instructions: str,
+    ) -> None:
+        """Initialise the adapter with the project context and settings."""
+        self._project_path = project_path
+        self._agent = create_serena_coder_agent(
+            settings=agent_settings,
+            mcp_settings=mcp_settings,
+            instructions=instructions,
+            project_path=project_path,
+        )
+
+    async def call(self, agent_input: AgentInput) -> AgentReturnTypes:
+        """Bridge Scenario input to the underlying Serena coding agent."""
+        _configure_scenario()
+        user_message = agent_input.last_new_user_message_str()
+        prompt = f"{user_message}\n\nRepository root: {self._project_path}"
+        result = cast(
+            "RunOutput",
+            self._agent.run(  # type: ignore[reportUnknownMemberType]
+                prompt,
+                session_id=agent_input.thread_id,
+            ),
+        )
+        messages = _format_agent_messages(result.messages)
+        if result.content:
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": cast(
+                        "str",
+                        result.get_content_as_string(),  # type: ignore[reportUnknownMemberType]
+                    ),
+                },
+            )
+        return messages or [
+            {
+                "role": "assistant",
+                "content": "I have no updates.",
+            },
+        ]
+
+
+class RepositoryQAAdapter(scenario.AgentAdapter):  # type: ignore[misc]
+    """Adapter that routes Scenario prompts to the repository QA agent."""
+
+    def __init__(
+        self,
+        *,
+        project_path: Path,
+        agent_settings: AgentSettings,
+        mcp_settings: MCPSettings,
+        instructions: str,
+    ) -> None:
+        """Initialise the adapter with repository configuration."""
+        self._project_path = project_path
+        self._agent = create_repository_qa_agent(
+            settings=agent_settings,
+            mcp_settings=mcp_settings,
+            instructions=instructions,
+            project_path=project_path,
+        )
+
+    async def call(self, agent_input: AgentInput) -> AgentReturnTypes:
+        """Handle a Scenario request by consulting the repository QA agent."""
+        _configure_scenario()
+        user_message = agent_input.last_new_user_message_str()
+        prompt = f"{user_message}\n\nRepository root: {self._project_path}"
+        result = cast(
+            "RunOutput",
+            self._agent.run(  # type: ignore[reportUnknownMemberType]
+                prompt,
+                session_id=agent_input.thread_id,
+            ),
+        )
+        messages = _format_agent_messages(result.messages)
+        if result.content:
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": cast(
+                        "str",
+                        result.get_content_as_string(),  # type: ignore[reportUnknownMemberType]
+                    ),
+                },
+            )
+        return messages or [
+            {
+                "role": "assistant",
+                "content": "Repository exploration completed.",
+            },
+        ]
+
+
+class TDDWorkflowAdapter(scenario.AgentAdapter):  # type: ignore[misc]
+    """Adapter that executes the TDD workflow and returns a textual summary."""
+
+    def __init__(self, workflow: Workflow) -> None:
+        """Store the workflow instance that will process Scenario prompts."""
+        self._workflow = workflow
+
+    async def call(self, agent_input: AgentInput) -> AgentReturnTypes:
+        """Execute the workflow and provide a summary for Scenario consumers."""
+        request = agent_input.last_new_user_message_str()
+        run: WorkflowRunOutput = self._workflow.run(
+            request,
+            session_id=agent_input.thread_id,
+        )
+        summary_lines = [
+            "TDD workflow execution summary:",
+            f"Status: {getattr(run.status, 'value', run.status)}",
+        ]
+        for entry in run.step_results or []:
+            steps: Iterable[Any]
+            is_iterable = isinstance(entry, Iterable) and not isinstance(
+                entry,
+                (dict, str, bytes),
+            )
+            steps = cast("Iterable[Any]", entry) if is_iterable else (entry,)
+            for step in steps:
+                name = getattr(step, "step_name", None) or "Unnamed step"
+                content = getattr(step, "content", "")
+                summary_lines.append(f"- {name}: {content}")
+        if run.content and run.content not in summary_lines:
+            summary_lines.append(str(run.content))
+        return [{"role": "assistant", "content": "\n".join(summary_lines)}]
+
+
+@pytest.fixture
+def scenario_project(tmp_path: Path) -> Path:
+    """Copy the virtual repository used by Scenario tests into a temp directory."""
+    template = Path(__file__).parent.parent / "fixtures" / "scenario_repo"
+    destination = tmp_path / "scenario-repo"
+    shutil.copytree(template, destination)
+    return destination
+
+
+def _build_agent_settings(name: str) -> AgentSettings:
+    """Return agent settings with an explicit display name."""
+    return AgentSettings(agent_name=name)
+
+
+def _build_mcp_settings() -> MCPSettings:
+    """Return MCP settings with optional overrides from the environment."""
+    overrides: dict[str, Any] = {}
+    command_override = _get_env("SCENARIO_SERENA_COMMAND")
+    if command_override:
+        overrides["lsp_walker_command"] = command_override
+    transport_override = _get_env("SCENARIO_SERENA_TRANSPORT")
+    if transport_override:
+        overrides["lsp_walker_transport"] = transport_override
+    url_override = _get_env("SCENARIO_SERENA_URL")
+    if url_override:
+        overrides["lsp_walker_url"] = url_override
+    if overrides:
+        return MCPSettings(**overrides)
+    return MCPSettings()
+
+
+@pytest.mark.asyncio
+async def test_serena_coder_resolves_todo(scenario_project: Path) -> None:
+    """Ensure the Serena coding agent can fix the known defect via Scenario."""
+    _require_credentials()
+    _configure_scenario()
+    agent = SerenaCodingAdapter(
+        project_path=scenario_project,
+        agent_settings=_build_agent_settings("Scenario Serena Coder"),
+        mcp_settings=_build_mcp_settings(),
+        instructions=(
+            "You are an autonomous engineer working in "
+            f"{scenario_project}. "
+            "Use the Serena MCP tools to inspect files, apply edits, and run pytest "
+            "before providing a final report."
+        ),
+    )
+    result = await scenario.run(
+        name="Implement multiply helper",
+        description=(
+            "The assistant must implement the multiply helper in "
+            "src/sample_package/calculator.py so that the pytest suite in "
+            "tests/test_calculator.py passes."
+        ),
+        agents=[
+            agent,
+            scenario.UserSimulatorAgent(
+                system_prompt=(
+                    "You are a product owner requesting the multiply helper be fixed. "
+                    "Ask the assistant to describe its plan, perform the change, "
+                    "run pytest -q, and summarise the results."
+                ),
+            ),
+            scenario.JudgeAgent(
+                criteria=[
+                    "Assistant fixes multiply in src/sample_package/calculator.py.",
+                    "Assistant runs pytest and confirms the suite passes.",
+                ],
+            ),
+        ],
+    )
+    assert result.success
+
+
+@pytest.mark.asyncio
+async def test_repo_qa_summarises_architecture(scenario_project: Path) -> None:
+    """Validate that the repository QA agent can answer structural questions."""
+    _require_credentials()
+    _configure_scenario()
+    agent = RepositoryQAAdapter(
+        project_path=scenario_project,
+        agent_settings=_build_agent_settings("Scenario Repo QA"),
+        mcp_settings=_build_mcp_settings(),
+        instructions=(
+            "You answer architecture questions about the repository at "
+            f"{scenario_project}. "
+            "Cite file paths and summarise the purpose of key modules and tests."
+        ),
+    )
+    result = await scenario.run(
+        name="Repository architecture overview",
+        description=(
+            "The user needs an explanation of where arithmetic helpers live, how they "
+            "are tested, and which documentation highlights the known multiply defect."
+        ),
+        agents=[
+            agent,
+            scenario.UserSimulatorAgent(
+                system_prompt=(
+                    "Ask targeted questions about project structure."
+                    " Reference file paths from docs/ and src/."
+                ),
+            ),
+            scenario.JudgeAgent(
+                criteria=[
+                    "Assistant cites docs/architecture.md in the summary.",
+                    "Assistant highlights calculator module and pytest suite.",
+                ],
+            ),
+        ],
+        max_turns=6,
+    )
+    assert result.success
+
+
+@pytest.mark.asyncio
+async def test_tdd_workflow_full_cycle(scenario_project: Path) -> None:
+    """Check that the TDD workflow integrates with Scenario conversations."""
+    _require_credentials()
+    _configure_scenario()
+
+    exploration_agent = create_repository_qa_agent(
+        settings=_build_agent_settings("Scenario Explorer"),
+        mcp_settings=_build_mcp_settings(),
+        instructions=(
+            "Inspect the repository at "
+            f"{scenario_project}, "
+            "focusing on the multiply defect and related tests. Summarise findings in "
+            "a structured way for downstream agents."
+        ),
+        project_path=scenario_project,
+    )
+    coding_agent = create_serena_coder_agent(
+        settings=_build_agent_settings("Scenario Implementer"),
+        mcp_settings=_build_mcp_settings(),
+        instructions=(
+            "Implement missing functionality in "
+            f"{scenario_project}. "
+            "Use Serena tools to edit files and run pytest -q."
+        ),
+        project_path=scenario_project,
+    )
+
+    workflow_config = TDDWorkflowConfig(
+        exploration_prompt=(
+            "Review the repository and confirm the multiply helper defect."
+        ),
+        test_prompt=(
+            "Write a precise pytest that captures the expected behaviour for multiply."
+        ),
+        implementation_prompt=(
+            "Implement the feature so all tests pass, then summarise the diff."
+        ),
+        test_command="pytest -q",
+        project_path=scenario_project,
+    )
+
+    workflow = create_tdd_workflow(
+        config=workflow_config,
+        exploration_runner=_AgentTextRunner(
+            exploration_agent,
+            project_path=scenario_project,
+            session_prefix="exploration",
+        ),
+        test_writer_runner=_AgentTextRunner(
+            coding_agent,
+            project_path=scenario_project,
+            session_prefix="test-writer",
+        ),
+        implementation_runner=_AgentTextRunner(
+            coding_agent,
+            project_path=scenario_project,
+            session_prefix="implementation",
+        ),
+    )
+
+    agent = TDDWorkflowAdapter(workflow)
+
+    result = await scenario.run(
+        name="TDD workflow for multiply helper",
+        description=(
+            "Coordinate exploration, test writing, and implementation so that the "
+            "multiply helper is fixed and tests pass."
+        ),
+        agents=[
+            agent,
+            scenario.UserSimulatorAgent(
+                system_prompt=(
+                    "Request the assistant to run the full TDD workflow and share "
+                    "status updates after each step."
+                ),
+            ),
+            scenario.JudgeAgent(
+                criteria=[
+                    "Workflow summary mentions both failing and passing pytest runs.",
+                    "Workflow summary references exploration and implementation steps.",
+                ],
+            ),
+        ],
+        max_turns=6,
+    )
+    assert result.success

--- a/tests/fixtures/scenario_repo/README.md
+++ b/tests/fixtures/scenario_repo/README.md
@@ -1,0 +1,23 @@
+# Scenario Sample Repository
+
+This repository emulates a small Python project that agents can explore during
+Scenario-based end-to-end tests. It intentionally contains a failing test and a
+TODO implementation so that coding agents can practice code search, editing, and
+test execution workflows.
+
+## Project Overview
+
+- The main package is `sample_package` inside the `src/` directory.
+- The `calculator.py` module exposes simple arithmetic helpers and contains a
+  `multiply` function with a known defect for agents to fix.
+- Tests live under `tests/` and rely on `pytest` with the `src/` directory on the
+  import path via `pyproject.toml` configuration.
+- `docs/architecture.md` includes background information that repository QA
+  agents can summarise.
+
+Agents running against this repository are expected to:
+
+1. Inspect project documentation to understand the requested change.
+2. Search for relevant source files and edit them using the available tools.
+3. Run the configured pytest suite (`pytest -q`) to verify their work.
+4. Provide a clear summary of the modifications and remaining tasks, if any.

--- a/tests/fixtures/scenario_repo/docs/architecture.md
+++ b/tests/fixtures/scenario_repo/docs/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Overview
+
+The project follows a simple `src/`-layout package with a single module. The
+`sample_package.calculator` module exposes arithmetic helpers that Scenario
+agents are expected to modify during tests.
+
+Key expectations for Scenario runs:
+
+- Repository QA agents should read this document and summarise the location of
+  the intentionally broken `multiply` implementation and its associated tests.
+- Coding agents should edit `src/sample_package/calculator.py` and run
+  `pytest -q` to ensure the suite in `tests/test_calculator.py` passes.
+- Workflow agents should orchestrate exploration, test authoring, and
+  implementation steps using the provided instructions.

--- a/tests/fixtures/scenario_repo/pyproject.toml
+++ b/tests/fixtures/scenario_repo/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "scenario-sample-project"
+version = "0.1.0"
+description = "Sample repository used for Scenario-based agent tests"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-q"

--- a/tests/fixtures/scenario_repo/src/sample_package/__init__.py
+++ b/tests/fixtures/scenario_repo/src/sample_package/__init__.py
@@ -1,0 +1,5 @@
+"""Sample package used to exercise Scenario-driven tests."""
+
+from .calculator import add, multiply
+
+__all__ = ["add", "multiply"]

--- a/tests/fixtures/scenario_repo/src/sample_package/calculator.py
+++ b/tests/fixtures/scenario_repo/src/sample_package/calculator.py
@@ -1,0 +1,39 @@
+"""Mathematical helpers with an intentionally broken implementation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OperationSummary:
+    """Structured summary returned by the calculator helpers."""
+
+    name: str
+    description: str
+
+
+def add(a: int, b: int) -> int:
+    """Return the sum of two integers."""
+    return a + b
+
+
+def multiply(a: int, b: int) -> int:
+    """Return the product of two integers.
+
+    The implementation intentionally returns an incorrect result so that coding
+    agents need to edit this file during Scenario tests.
+    """
+    # Placeholder implementation replaced by coding agents during Scenario tests
+    return a + b
+
+
+def describe() -> OperationSummary:
+    """Provide a human readable summary of the operations."""
+    return OperationSummary(
+        name="Basic arithmetic",
+        description=(
+            "Provides helpers for adding and multiplying integers. The multiply "
+            "function intentionally contains a defect to support Scenario test cases."
+        ),
+    )

--- a/tests/fixtures/scenario_repo/tests/__init__.py
+++ b/tests/fixtures/scenario_repo/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Pytest package marker for Scenario sample repository tests."""

--- a/tests/fixtures/scenario_repo/tests/test_calculator.py
+++ b/tests/fixtures/scenario_repo/tests/test_calculator.py
@@ -1,0 +1,22 @@
+# pyright: reportMissingImports=false, reportUnknownVariableType=false
+# pyright: reportUnknownMemberType=false
+"""Tests for the intentionally flawed calculator module."""
+
+from sample_package.calculator import OperationSummary, add, describe, multiply
+
+
+def test_add_returns_sum() -> None:
+    """Verify the addition helper works as expected."""
+    assert add(2, 3) == 5
+
+
+def test_multiply_returns_product() -> None:
+    """Expose the known defect so coding agents must fix it."""
+    assert multiply(6, 7) == 42
+
+
+def test_describe_includes_context() -> None:
+    """Ensure the description documents the known defect."""
+    summary = describe()
+    assert isinstance(summary, OperationSummary)
+    assert "defect" in summary.description.lower()

--- a/typings/scenario/__init__.pyi
+++ b/typings/scenario/__init__.pyi
@@ -1,0 +1,34 @@
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+class AgentInput(Protocol):
+    thread_id: str
+
+    def last_new_user_message_str(self) -> str: ...
+
+type AgentReturnTypes = Any
+
+class AgentAdapter:
+    async def call(self, agent_input: AgentInput) -> AgentReturnTypes: ...
+
+class UserSimulatorAgent:
+    def __init__(self, *, system_prompt: str | None = ...) -> None: ...
+
+class JudgeAgent:
+    def __init__(self, *, criteria: Sequence[str]) -> None: ...
+
+def configure(
+    *,
+    default_model: str | None = ...,
+    cache_key: str | None = ...,
+    max_turns: int | None = ...,
+) -> None: ...
+
+async def run(
+    *,
+    name: str,
+    description: str,
+    agents: Sequence[Any],
+    max_turns: int | None = ...,
+) -> Any: ...


### PR DESCRIPTION
## Summary
- integrate the Scenario testing library into the agent and workflow end-to-end tests, configuring credentials and adapters around the real scenario.run API
- add the langwatch-scenario development dependency and provide Scenario typing stubs so Pyright recognises the module interfaces
- tidy the LLM factory exports and type hints to satisfy linting after the new dependency installation

## Testing
- `uv run nox -s lint`
- `uv run nox -s typing`


------
https://chatgpt.com/codex/tasks/task_e_68d279ab079c833087cdbcff86eba9fe