### PR TITLE
Add workflow lint support with YAML configuration

### DIFF
--- a/src/clean_interfaces/llm/__init__.py
+++ b/src/clean_interfaces/llm/__init__.py
@@ -4,5 +4,5 @@ This package exposes a factory to create provider-specific model instances.
 """
 from .factory import create_model, LLMProviderNotAvailableError
 
-__all__ = ["create_model", "LLMProviderNotAvailableError"]
+__all__ = ["LLMProviderNotAvailableError", "create_model"]
 

--- a/src/clean_interfaces/llm/factory.py
+++ b/src/clean_interfaces/llm/factory.py
@@ -9,6 +9,7 @@ Notes:
   to preserve existing test hooks that patch that symbol in those modules.
 - For other providers, this factory returns the appropriate model instance if
   the corresponding integration is available in ``agno``.
+
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ class LLMProviderNotAvailableError(RuntimeError):
     """Raised when the requested provider integration is not available."""
 
 
-def _build_openai_model(settings: "AgentSettings") -> Any:
+def _build_openai_model(settings: AgentSettings) -> Any:
     """Construct an OpenAIChat model using OpenAI credentials.
 
     Although agents instantiate OpenAI models directly, this is exposed for
@@ -48,7 +49,7 @@ def _build_openai_model(settings: "AgentSettings") -> Any:
     return OpenAIChat(**kwargs)
 
 
-def _build_azure_openai_model(settings: "AgentSettings") -> Any:
+def _build_azure_openai_model(settings: AgentSettings) -> Any:
     """Construct an Azure OpenAI model instance.
 
     Attempts multiple import paths to accommodate possible agno versions.
@@ -60,7 +61,7 @@ def _build_azure_openai_model(settings: "AgentSettings") -> Any:
     ):
         try:
             module = __import__(path, fromlist=["AzureOpenAIChat"])  # type: ignore[assignment]
-            model_class = getattr(module, "AzureOpenAIChat")
+            model_class = module.AzureOpenAIChat
             break
         except Exception as exc:  # pragma: no cover - optional integration
             logger.debug("AzureOpenAIChat import failed from %s: %s", path, exc)
@@ -95,7 +96,7 @@ def _build_azure_openai_model(settings: "AgentSettings") -> Any:
     )
 
 
-def _build_anthropic_model(settings: "AgentSettings") -> Any:
+def _build_anthropic_model(settings: AgentSettings) -> Any:
     """Construct an Anthropic model instance."""
     model_class: Any | None = None
     for path in (
@@ -103,7 +104,7 @@ def _build_anthropic_model(settings: "AgentSettings") -> Any:
     ):
         try:
             module = __import__(path, fromlist=["AnthropicChat"])  # type: ignore[assignment]
-            model_class = getattr(module, "AnthropicChat")
+            model_class = module.AnthropicChat
             break
         except Exception as exc:  # pragma: no cover - optional integration
             logger.debug("AnthropicChat import failed from %s: %s", path, exc)
@@ -125,7 +126,7 @@ def _build_anthropic_model(settings: "AgentSettings") -> Any:
     return model_class(**kwargs)
 
 
-def _build_gemini_model(settings: "AgentSettings") -> Any:
+def _build_gemini_model(settings: AgentSettings) -> Any:
     """Construct a Google Gemini model instance."""
     model_class: Any | None = None
     for path in (
@@ -134,7 +135,7 @@ def _build_gemini_model(settings: "AgentSettings") -> Any:
     ):
         try:
             module = __import__(path, fromlist=["GeminiChat"])  # type: ignore[assignment]
-            model_class = getattr(module, "GeminiChat")
+            model_class = module.GeminiChat
             break
         except Exception as exc:  # pragma: no cover - optional integration
             logger.debug("GeminiChat import failed from %s: %s", path, exc)
@@ -156,7 +157,7 @@ def _build_gemini_model(settings: "AgentSettings") -> Any:
     return model_class(**kwargs)
 
 
-def create_model(settings: "AgentSettings") -> Any:
+def create_model(settings: AgentSettings) -> Any:
     """Create a provider-specific agno model instance.
 
     Args:
@@ -168,6 +169,7 @@ def create_model(settings: "AgentSettings") -> Any:
     Raises:
         LLMProviderNotAvailableError: If the provider's model is not available.
         ValueError: If the provider is unsupported or configuration is incomplete.
+
     """
     provider = getattr(settings, "provider", "openai")
     if provider == "openai":

--- a/src/clean_interfaces/workflow/__init__.py
+++ b/src/clean_interfaces/workflow/__init__.py
@@ -6,6 +6,9 @@ from .test_commands import (
     TestCommandExecutor,
     TestCommandManager,
     TestCommandResult,
+    WorkflowCommandConfig,
+    create_manager_from_config,
+    load_workflow_command_config,
 )
 
 __all__ = [
@@ -13,5 +16,8 @@ __all__ = [
     "TestCommandExecutor",
     "TestCommandManager",
     "TestCommandResult",
+    "WorkflowCommandConfig",
+    "create_manager_from_config",
     "create_tdd_workflow",
+    "load_workflow_command_config",
 ]

--- a/src/clean_interfaces/workflow/test_commands.py
+++ b/src/clean_interfaces/workflow/test_commands.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import shlex
 import subprocess
 import time
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from clean_interfaces.base import BaseComponent
+from clean_interfaces.utils.file_handler import FileHandler
+
+CommandInput = str | Iterable[str] | Iterable[Iterable[str]]
+CommandSequence = tuple[tuple[str, ...], ...]
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
     from pathlib import Path
 
 
@@ -20,7 +24,7 @@ class TestCommandExecutionError(RuntimeError):
 
     def __init__(
         self,
-        command: Sequence[str],
+        command: tuple[str, ...],
         message: str,
         *,
         stderr: str | None = None,
@@ -85,24 +89,88 @@ class TestCommandResult:
 class TestCommandManager(BaseComponent):
     """Manage named test commands and resolve aliases."""
 
-    def __init__(self) -> None:
-        """Initialise the manager with default command aliases."""
-        super().__init__()
-        self._commands: dict[str, tuple[str, ...]] = {
-            "pytest": ("uv", "run", "pytest"),
-        }
+    _EMPTY_COMMAND_MESSAGE = "Command must contain at least one element"
 
-    def register(self, name: str, command: Iterable[str]) -> None:
+    def __init__(
+        self,
+        *,
+        commands: Mapping[str, CommandInput] | None = None,
+        include_defaults: bool = True,
+    ) -> None:
+        """Initialise the manager with optional command aliases."""
+        super().__init__()
+        self._commands: dict[str, CommandSequence] = {}
+        if include_defaults:
+            self.register("pytest", ("uv", "run", "pytest"))
+        if commands:
+            self.register_many(commands)
+
+    @classmethod
+    def normalise(cls, command: CommandInput) -> CommandSequence:
+        """Normalise a command input into canonical tuple form."""
+        if isinstance(command, str):
+            return cls._normalise_from_string(command)
+
+        iterable_command = cast("Iterable[Any]", command)
+        return cls._normalise_from_iterable(iterable_command)
+
+    @classmethod
+    def _normalise_from_string(cls, command: str) -> CommandSequence:
+        """Normalise a shell-style string command."""
+        return (cls._ensure_parts(shlex.split(command)),)
+
+    @classmethod
+    def _normalise_from_iterable(cls, command: Iterable[Any]) -> CommandSequence:
+        """Normalise an iterable of commands or arguments."""
+        elements = list(command)
+        if not elements:
+            raise ValueError(cls._EMPTY_COMMAND_MESSAGE)
+
+        if all(isinstance(element, str) for element in elements):
+            return (cls._ensure_parts([str(element) for element in elements]),)
+
+        sequences = [cls._normalise_nested_element(element) for element in elements]
+        return tuple(sequences)
+
+    @classmethod
+    def _normalise_nested_element(cls, element: Any) -> tuple[str, ...]:
+        """Normalise a nested command element."""
+        if isinstance(element, str):
+            return cls._ensure_parts(shlex.split(element))
+        try:
+            iterator = iter(cast("Iterable[Any]", element))
+        except TypeError as exc:
+            message = f"Unsupported command element type: {type(element)!r}"
+            raise TypeError(message) from exc
+        parts = [str(part) for part in iterator]
+        return cls._ensure_parts(parts)
+
+    @staticmethod
+    def _ensure_parts(parts: Iterable[str]) -> tuple[str, ...]:
+        """Convert command parts into a tuple, ensuring it is not empty."""
+        parts_tuple = tuple(parts)
+        if not parts_tuple:
+            raise ValueError(TestCommandManager._EMPTY_COMMAND_MESSAGE)
+        return parts_tuple
+
+    def register(self, name: str, command: CommandInput) -> None:
         """Register a new named command alias."""
-        command_tuple = tuple(command)
-        if not command_tuple:
-            message = "Command must contain at least one element"
-            raise ValueError(message)
-        self.logger.debug("Registering test command", name=name, command=command_tuple)
-        self._commands[name] = command_tuple
+        sequences = self.normalise(command)
+        self.logger.debug("Registering test command", name=name, command=sequences)
+        self._commands[name] = sequences
+
+    def register_many(self, commands: Mapping[str, CommandInput]) -> None:
+        """Register multiple command aliases at once."""
+        for name, command in commands.items():
+            self.register(name, command)
 
     def resolve(self, spec: str) -> tuple[str, ...]:
-        """Resolve a command specification into an executable tuple."""
+        """Resolve a command specification into a single executable tuple."""
+        commands = self.resolve_all(spec)
+        return commands[0]
+
+    def resolve_all(self, spec: str) -> CommandSequence:
+        """Resolve a command specification into all configured commands."""
         if not spec:
             message = "Command specification cannot be empty"
             raise ValueError(message)
@@ -110,7 +178,11 @@ class TestCommandManager(BaseComponent):
         if spec in self._commands:
             return self._commands[spec]
 
-        return tuple(shlex.split(spec))
+        parsed = shlex.split(spec)
+        if not parsed:
+            message = "Command specification cannot be empty"
+            raise ValueError(message)
+        return (tuple(parsed),)
 
 
 class TestCommandExecutor(BaseComponent):
@@ -137,9 +209,26 @@ class TestCommandExecutor(BaseComponent):
     ) -> TestCommandResult:
         """Execute the provided command specification and return the result."""
         command = self._manager.resolve(command_spec)
-        if not command:
-            raise TestCommandExecutionError(command, "Resolved command is empty")
+        return self._execute(command, timeout=timeout)
 
+    def run_all(
+        self,
+        command_spec: str,
+        *,
+        timeout: float | None = None,
+    ) -> tuple[TestCommandResult, ...]:
+        """Execute all commands associated with the specification."""
+        commands = self._manager.resolve_all(command_spec)
+        results = [self._execute(command, timeout=timeout) for command in commands]
+        return tuple(results)
+
+    def _execute(
+        self,
+        command: tuple[str, ...],
+        *,
+        timeout: float | None,
+    ) -> TestCommandResult:
+        """Execute a single command sequence and capture the result."""
         self.logger.info(
             "Running test command",
             command=command,
@@ -186,3 +275,103 @@ class TestCommandExecutor(BaseComponent):
             duration=result.duration,
         )
         return result
+
+
+@dataclass(slots=True)
+class WorkflowCommandConfig:
+    """Command configuration for agent workflows."""
+
+    tests: dict[str, CommandSequence]
+    lint: dict[str, CommandSequence]
+
+    def __post_init__(self) -> None:
+        """Normalise provided command mappings into dictionaries."""
+        self.tests = dict(self.tests)
+        self.lint = dict(self.lint)
+
+    @classmethod
+    def empty(cls) -> WorkflowCommandConfig:
+        """Return an empty configuration."""
+        return cls(tests={}, lint={})
+
+    def commands_for(
+        self,
+        category: Literal["tests", "lint"],
+    ) -> dict[str, CommandSequence]:
+        """Return a shallow copy of commands for the given category."""
+        return dict(getattr(self, category))
+
+    def register_tests(self, manager: TestCommandManager) -> None:
+        """Register test commands with the provided manager."""
+        for name, command in self.tests.items():
+            manager.register(name, command)
+
+    def register_lint(self, manager: TestCommandManager) -> None:
+        """Register lint commands with the provided manager."""
+        for name, command in self.lint.items():
+            manager.register(name, command)
+
+
+def load_workflow_command_config(
+    path: str | Path,
+    *,
+    file_handler: FileHandler | None = None,
+) -> WorkflowCommandConfig:
+    """Load workflow command configuration from a YAML file."""
+    handler = file_handler or FileHandler()
+    data = handler.read_yaml(path)
+    if data is None:
+        return WorkflowCommandConfig.empty()
+    if not isinstance(data, Mapping):
+        message = "Workflow command configuration must be a mapping"
+        raise TypeError(message)
+
+    typed_data = cast("Mapping[str, object]", data)
+    tests = _parse_command_section(typed_data.get("tests"), section="tests")
+    lint = _parse_command_section(typed_data.get("lint"), section="lint")
+    return WorkflowCommandConfig(tests=tests, lint=lint)
+
+
+def create_manager_from_config(
+    config: WorkflowCommandConfig,
+    *,
+    category: Literal["tests", "lint"],
+    include_defaults: bool | None = None,
+) -> TestCommandManager:
+    """Create a :class:`TestCommandManager` populated from configuration."""
+    include = include_defaults if include_defaults is not None else category == "tests"
+    manager = TestCommandManager(include_defaults=include)
+    commands = config.commands_for(category)
+    if commands:
+        manager.register_many(commands)
+    return manager
+
+
+def _parse_command_section(
+    section_data: Any,
+    *,
+    section: str,
+) -> dict[str, CommandSequence]:
+    """Parse a command section from configuration data."""
+    if section_data is None:
+        return {}
+    if not isinstance(section_data, Mapping):
+        message = f"{section} section must be a mapping of command names to commands"
+        raise TypeError(message)
+
+    typed_section = cast("Mapping[object, object]", section_data)
+
+    result: dict[str, CommandSequence] = {}
+    for raw_name, raw_command in typed_section.items():
+        if not isinstance(raw_name, str):
+            message = "Command names must be strings"
+            raise TypeError(message)
+        try:
+            command_input = cast("CommandInput", raw_command)
+            result[raw_name] = TestCommandManager.normalise(command_input)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive guard
+            message = (
+                f"Invalid command definition for {section} command '{raw_name}': {exc}"
+            )
+            raise ValueError(message) from exc
+    return result

--- a/tests/unit/clean_interfaces/workflow/test_test_commands.py
+++ b/tests/unit/clean_interfaces/workflow/test_test_commands.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
+from typing import Any
 
 from clean_interfaces.workflow.test_commands import (
     TestCommandExecutor,
@@ -35,6 +37,59 @@ def test_executor_runs_registered_command() -> None:
     assert result.succeeded
     assert "hello" in result.stdout
     assert result.command_display().startswith(sys.executable)
+
+
+def test_manager_registers_multiple_sequences() -> None:
+    """It accepts multiple commands for a single alias."""
+    manager = TestCommandManager(include_defaults=False)
+    manager.register(
+        "lint",
+        [
+            ["uv", "run", "ruff", "format"],
+            "uv run ruff check",
+        ],
+    )
+
+    first_command = manager.resolve("lint")
+    assert first_command == ("uv", "run", "ruff", "format")
+
+    all_commands = manager.resolve_all("lint")
+    assert all_commands == (
+        ("uv", "run", "ruff", "format"),
+        ("uv", "run", "ruff", "check"),
+    )
+
+
+def test_executor_run_all_executes_every_command(monkeypatch: Any) -> None:
+    """It executes all commands in sequence and returns individual results."""
+    manager = TestCommandManager(include_defaults=False)
+    manager.register(
+        "lint",
+        [
+            ["uv", "run", "ruff", "format"],
+            ["uv", "run", "ruff", "check"],
+        ],
+    )
+
+    executor = TestCommandExecutor(manager)
+    recorded: list[tuple[str, ...]] = []
+
+    def fake_run(command: tuple[str, ...], **_: object) -> SimpleNamespace:
+        recorded.append(tuple(command))
+        index = len(recorded)
+        return SimpleNamespace(returncode=0, stdout=f"out-{index}", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    results = executor.run_all("lint")
+
+    assert recorded == [
+        ("uv", "run", "ruff", "format"),
+        ("uv", "run", "ruff", "check"),
+    ]
+    assert len(results) == 2
+    assert all(result.succeeded for result in results)
+    assert {result.stdout for result in results} == {"out-1", "out-2"}
 
 
 def test_result_format_includes_outputs() -> None:

--- a/tests/unit/clean_interfaces/workflow/test_workflow_command_config.py
+++ b/tests/unit/clean_interfaces/workflow/test_workflow_command_config.py
@@ -1,0 +1,86 @@
+"""Tests for workflow command configuration utilities."""
+
+from __future__ import annotations
+
+import pytest
+from typing import TYPE_CHECKING
+
+from clean_interfaces.workflow.test_commands import (
+    WorkflowCommandConfig,
+    create_manager_from_config,
+    load_workflow_command_config,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_load_workflow_command_config_parses_yaml(tmp_path: Path) -> None:
+    """It loads lint and test commands with multiple entries."""
+    config_path = tmp_path / "commands.yaml"
+    config_path.write_text(
+        """
+        tests:
+          pytest:
+            - uv run pytest
+            - [uv, run, pytest, -k, smoke]
+        lint:
+          default:
+            - [uv, run, ruff, format]
+            - uv run ruff check
+        """,
+        encoding="utf-8",
+    )
+
+    config = load_workflow_command_config(config_path)
+    assert config.tests["pytest"] == (
+        ("uv", "run", "pytest"),
+        ("uv", "run", "pytest", "-k", "smoke"),
+    )
+    assert config.lint["default"] == (
+        ("uv", "run", "ruff", "format"),
+        ("uv", "run", "ruff", "check"),
+    )
+
+
+def test_create_manager_from_config_respects_category_defaults() -> None:
+    """It creates managers with and without default commands appropriately."""
+    config = WorkflowCommandConfig(
+        tests={"pytest": (("uv", "run", "pytest"),)},
+        lint={
+            "quality": (
+                ("uv", "run", "ruff", "format"),
+                ("uv", "run", "ruff", "check"),
+            ),
+        },
+    )
+
+    test_manager = create_manager_from_config(config, category="tests")
+    assert test_manager.resolve("pytest") == ("uv", "run", "pytest")
+
+    lint_manager = create_manager_from_config(config, category="lint")
+    assert lint_manager.resolve_all("quality") == (
+        ("uv", "run", "ruff", "format"),
+        ("uv", "run", "ruff", "check"),
+    )
+    # Ensure the default pytest alias is not automatically added for lint managers.
+    assert lint_manager.resolve_all("pytest") == (("pytest",),)
+
+
+def test_load_workflow_command_config_rejects_invalid_structure(tmp_path: Path) -> None:
+    """It raises an error when the YAML structure is not a mapping."""
+    config_path = tmp_path / "commands.yaml"
+    config_path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="configuration must be a mapping"):
+        load_workflow_command_config(config_path)
+
+    config_path.write_text(
+        """
+        tests:
+          - not-a-mapping
+        """,
+        encoding="utf-8",
+    )
+    with pytest.raises(TypeError, match="tests section must be a mapping"):
+        load_workflow_command_config(config_path)


### PR DESCRIPTION
## Summary
- extend the workflow command utilities to normalise multi-command sequences, execute batches, and load definitions from YAML via the FileHandler
- add helpers and unit tests to validate lint/test command configuration loading and execution
- apply lint-driven cleanups in the LLM factory exports

## Testing
- uv run pytest tests/unit/clean_interfaces/workflow/test_test_commands.py tests/unit/clean_interfaces/workflow/test_workflow_command_config.py
- uv run nox -s lint
- uv run nox -s typing

------
https://chatgpt.com/codex/tasks/task_e_68d3d64a96cc8330a022904189164293